### PR TITLE
Fix missing os import in detection script

### DIFF
--- a/dll-related/Detect-SRC-Modification.py
+++ b/dll-related/Detect-SRC-Modification.py
@@ -1,6 +1,7 @@
 import threading
 import time
 import inspect
+import os
 
 def oldprog():
     print("OLDPROG FUNCTION ALIVE...")


### PR DESCRIPTION
## Summary
- detect source modification thread uses os but never imported it

## Testing
- `python3 -m py_compile dll-related/Detect-SRC-Modification.py`

------
https://chatgpt.com/codex/tasks/task_e_68438ff125348326b9549159fb2822c7